### PR TITLE
Update badge variant in BranchDetailDialog for report status represen…

### DIFF
--- a/src/components/consolidated-view.tsx
+++ b/src/components/consolidated-view.tsx
@@ -439,7 +439,7 @@ const BranchDetailDialog = ({ selectedBranch, selectedBranchData, onClose }: Bra
                     </TableCell>
                     <TableCell className="dark:text-gray-300 text-right">
                       <Badge 
-                        variant={report.status === 'Approved' ? 'success' : report.status === 'Pending' ? 'warning' : 'destructive'}
+                        variant={report.status === 'Approved' ? 'success' : report.status === 'Pending' ? 'secondary' : 'default'}
                         className="ml-auto"
                       >
                         {report.status}


### PR DESCRIPTION
…tation

- Changed the badge variant for 'Pending' status from 'warning' to 'secondary' and updated the 'destructive' variant to 'default' for improved clarity in status indication.